### PR TITLE
enable physics component

### DIFF
--- a/settings/v2/packages/engine.json
+++ b/settings/v2/packages/engine.json
@@ -27,7 +27,7 @@
         "_value": true
       },
       "physics": {
-        "_value": false,
+        "_value": true,
         "_option": "physics-ammo"
       },
       "physics-ammo": {


### PR DESCRIPTION
enable the physics component, so that `physics-benchmark` can run directly.